### PR TITLE
Add Dockerfile to allow use to us "Repository Links"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# Note: This image is really only use to allow the jupyterlab image rebuild to be
+# triggered when this repo is updated. We are using docker hubs "Repository Links".
+FROM python:3.6-slim
+
+COPY ./ /jupyterlab_cjson
+
+RUN cd /jupyterlab_cjson && \
+  pip install .


### PR DESCRIPTION
This image is only really used to allow us to use docker hub "Repository Links" to trigger a rebuild of our jupyterlab image.