### PR TITLE
Pass isovalue and normal mode metadata to oc-molecule

### DIFF
--- a/src/components/cjson/index.tsx
+++ b/src/components/cjson/index.tsx
@@ -41,7 +41,7 @@ export class CJSONComponent extends React.Component<IProps, IState> {
   }
 
   render() {
-    const { data } = this.props;
+    const { data, metadata } = this.props;
 
     const cjson: IChemJson = data as IChemJson;
     // We use React.createElement(...) here otherwise tsc complains about
@@ -51,7 +51,9 @@ export class CJSONComponent extends React.Component<IProps, IState> {
       {},
       // Props
       {
-        cjson: cjson
+        cjson: cjson,
+        isoValue: metadata.isoValue,
+        iMode: metadata.animateMode
       }
     );
     const molecule = React.createElement('oc-molecule', {


### PR DESCRIPTION
![screenshot_2018-11-16 jupyterlab 4](https://user-images.githubusercontent.com/15913822/48643902-0ce9d600-e9af-11e8-8343-753efe173bd4.png)
