### PR TITLE
Update reqs for @lumino deps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "@jupyterlab/application": "^3.0.2",
-    "@lumino/coreutils": "1.5.3",
-    "@lumino/widgets": "1.17.0",
+    "@lumino/coreutils": "^1.5.3",
+    "@lumino/widgets": "^1.17.0",
     "@material-ui/core": "^3.9.2",
     "@material-ui/icons": "^3.0.2",
     "@openchemistry/energy-plot": "^0.1.38",


### PR DESCRIPTION
Make @lumino/widgets and @lumino/coreutils minimum versions, rather than fixed. Allows automatic installation with Jupyerlab 3.2.4.